### PR TITLE
Skip urls with non-200 http status

### DIFF
--- a/Lib/corpuscrawler/util.py
+++ b/Lib/corpuscrawler/util.py
@@ -764,7 +764,9 @@ def find_wordpress_urls(crawler, site):
         for page in range(1, 1 + max([0] + pages)):
             pgurl = urljoin(caturl, 'page/%d/' % page) if page > 1 else caturl
             pgdoc = crawler.fetch(pgurl)
-            assert pgdoc.status == 200, (pgdoc.status, pgurl)
+            if pgdoc.status != 200:
+                print('Error %3d:      %s' % (pgdoc.status, pgurl))
+                continue
             pgcontent = pgdoc.content.decode('utf-8')
             for url in re.findall(r'"(%s[^"]+)"' % site, pgcontent):
                 url = replace_html_entities(url.split('#')[0])


### PR DESCRIPTION
This pull request is opened in response to https://github.com/google/corpuscrawler/issues/50#issuecomment-542928663. Instead of crashing the program if the http status is not 200, the program will just skip the url.